### PR TITLE
Fix TypeParser + TypeLexer

### DIFF
--- a/src/Type/Parser/TypeLexer.php
+++ b/src/Type/Parser/TypeLexer.php
@@ -33,7 +33,7 @@ class TypeLexer extends AbstractLexer
     {
         return [
             '\'(?:[^\']|\'\')*\'',
-            '([a-z0-9\\\\]+)',
+            '[a-z0-9\\\\]+',
         ];
     }
 

--- a/src/Type/Parser/TypeParser.php
+++ b/src/Type/Parser/TypeParser.php
@@ -45,6 +45,7 @@ class TypeParser implements TypeParserInterface
 
         $this->lexer->setInput($type);
         $this->walk();
+        $this->walk();
 
         try {
             return $this->parseType();
@@ -67,6 +68,7 @@ class TypeParser implements TypeParserInterface
     private function parseName()
     {
         $token = $this->validateToken(TypeLexer::T_NAME);
+        $this->walk();
 
         return $token['value'];
     }
@@ -93,6 +95,7 @@ class TypeParser implements TypeParserInterface
         }
 
         $this->validateToken(TypeLexer::T_GREATER_THAN);
+        $this->walk();
 
         return $options;
     }
@@ -102,9 +105,11 @@ class TypeParser implements TypeParserInterface
      */
     private function parseOptionName()
     {
+        $this->walk();
         $token = $this->lexer->token;
         $this->walk();
         $this->validateToken(TypeLexer::T_EQUAL);
+        $this->walk();
 
         return $token['value'];
     }
@@ -117,17 +122,12 @@ class TypeParser implements TypeParserInterface
         $token = $this->lexer->token;
 
         if ($token['type'] === TypeLexer::T_STRING) {
-            $result = $token['value'];
             $this->walk();
-        } else {
-            $result = $this->parseType();
+
+            return $token['value'];
         }
 
-        if ($this->lexer->token['type'] === TypeLexer::T_COMMA) {
-            $this->walk();
-        }
-
-        return $result;
+        return $this->parseType();
     }
 
     /**
@@ -147,25 +147,13 @@ class TypeParser implements TypeParserInterface
             ));
         }
 
-        $this->walk();
-
         return $token;
     }
 
-    /**
-     * @param int $count
-     *
-     * @return mixed[]
-     */
-    private function walk($count = 1)
+    private function walk()
     {
-        $token = $nextToken = $this->lexer->token;
+        $this->lexer->moveNext();
 
-        for ($i = 0; ($i < $count) || ($token === $nextToken); ++$i) {
-            $this->lexer->moveNext();
-            $nextToken = $this->lexer->token;
-        }
-
-        return $nextToken;
+        return $this->lexer->token;
     }
 }


### PR DESCRIPTION
Hi, 
This gonna to fix 1 wrong doctrine/lexer usage.
The wrong usage was located in the [TypeLexer](https://github.com/egeloen/ivory-serializer/blob/master/src/Type/Parser/TypeLexer.php#L36)
```php
    protected function getCatchablePatterns()
    {
        return [
            '\'(?:[^\']|\'\')*\'',
            '([a-z0-9\\\\]+)', // <----- You must not use parenthesis here
        ];
    }
```
You must not use `group capture` (parenthesis) because this regex was use in [preg_split](https://github.com/doctrine/lexer/blob/master/lib/Doctrine/Common/Lexer/AbstractLexer.php#L259) function
For example with `array<key=int, value=string>`
if you use `([a-z0-9\\\\]+)` you get 15 tokens in the lexer

```
Array
(
    [0] => Array
        (
            [value] => array
            [type] => 2
            [position] => 0
        )
    [1] => Array
        (
            [value] => array
            [type] => 2
            [position] => 0
        )
    [2] => Array
        (
            [value] => <
            [type] => 5
            [position] => 5
        )
    [3] => Array
        (
            [value] => key
            [type] => 2
            [position] => 6
        )
    [4] => Array
        (
            [value] => key
            [type] => 2
            [position] => 6
        )
    [5] => Array
        (
            [value] => =
            [type] => 7
            [position] => 9
        )
    [6] => Array
        (
            [value] => int
            [type] => 2
            [position] => 10
        )
    [7] => Array
        (
            [value] => int
            [type] => 2
            [position] => 10
        )
    [8] => Array
        (
            [value] => ,
            [type] => 6
            [position] => 13
        )
    [9] => Array
        (
            [value] => value
            [type] => 2
            [position] => 15
        )
    [10] => Array
        (
            [value] => value
            [type] => 2
            [position] => 15
        )
    [11] => Array
        (
            [value] => =
            [type] => 7
            [position] => 20
        )
    [12] => Array
        (
            [value] => string
            [type] => 2
            [position] => 21
        )
    [13] => Array
        (
            [value] => string
            [type] => 2
            [position] => 21
        )
    [14] => Array
        (
            [value] => >
            [type] => 4
            [position] => 27
        )
)
```

and if you use `[a-z0-9\\\\]+` you get 10 tokens in the lexer
```
Array
(
    [0] => Array
        (
            [value] => array
            [type] => 2
            [position] => 0
        )
    [1] => Array
        (
            [value] => <
            [type] => 5
            [position] => 5
        )
    [2] => Array
        (
            [value] => key
            [type] => 2
            [position] => 6
        )
    [3] => Array
        (
            [value] => =
            [type] => 7
            [position] => 9
        )
    [4] => Array
        (
            [value] => int
            [type] => 2
            [position] => 10
        )
    [5] => Array
        (
            [value] => ,
            [type] => 6
            [position] => 13
        )
    [6] => Array
        (
            [value] => value
            [type] => 2
            [position] => 15
        )
    [7] => Array
        (
            [value] => =
            [type] => 7
            [position] => 20
        )
    [8] => Array
        (
            [value] => string
            [type] => 2
            [position] => 21
        )
    [9] => Array
        (
            [value] => >
            [type] => 4
            [position] => 27
        )
)
```
so i fix the TypeParser::walk() function in order to drop the foreach (currently was a workaround to skip the token doublon capture by the regex parenthesis)

I'm not happy to set a lot of `->walk()` call everywhere in the `TypeParser` but they are needed.

**This PR is related to https://github.com/doctrine/lexer/pull/12#issuecomment-388956012**
**I've also tested with https://github.com/doctrine/lexer/pull/12/files#diff-3945e835e8d3a0ad8409023030a9db04R262**